### PR TITLE
Remove parentheses for assertions

### DIFF
--- a/StormReactor/waterQuality.py
+++ b/StormReactor/waterQuality.py
@@ -139,7 +139,7 @@ class WaterQuality:
         R = pollutant removal fraction (unitless)
         """
 
-        assert(0 <= parameters["R"] <= 1, self._generateErrorMessage("R", "Pollutant removal fraction", 2, minVal=0, maxVal=1))
+        assert 0 <= parameters["R"] <= 1, self._generateErrorMessage("R", "Pollutant removal fraction", 2, minVal=0, maxVal=1)
 
         if self.flag == 0:
             # Get SWMM parameter
@@ -167,8 +167,8 @@ class WaterQuality:
         R2 = pollutant removal fraction for other pollutant (unitless)
         """
 
-        assert(0 <= parameters["R1"] <= 1, self._generateErrorMessage("R1", "Pollutant removal fraction", 2, minVal=0, maxVal=1))
-        assert(0 <= parameters["R2"] <= 1, self._generateErrorMessage("R2", "Pollutant removal fraction for other pollutant", 2, minVal=0, maxVal=1))
+        assert 0 <= parameters["R1"] <= 1, self._generateErrorMessage("R1", "Pollutant removal fraction", 2, minVal=0, maxVal=1)
+        assert 0 <= parameters["R2"] <= 1, self._generateErrorMessage("R2", "Pollutant removal fraction for other pollutant", 2, minVal=0, maxVal=1)
 
         if self.flag == 0:
             # Get SWMM parameter
@@ -197,7 +197,7 @@ class WaterQuality:
         R_u = upper removal rate (unitless)
         """
 
-        assert(parameters["BC"]>=0, self._generateErrorMessage("BC", "Boundary concentration", 0, minVal=0))
+        assert parameters["BC"]>=0, self._generateErrorMessage("BC", "Boundary concentration", 0, minVal=0)
 
         parameters = parameters
 
@@ -235,7 +235,7 @@ class WaterQuality:
             n   = reaction order (first order, second order, etc.) (unitless)
             """
 
-            assert(parameters["n"]>=0, self._generateErrorMessage("n", "Reaction order", 0, minVal=0))
+            assert parameters["n"]>=0, self._generateErrorMessage("n", "Reaction order", 0, minVal=0)
 
             parameters = parameters
 
@@ -272,7 +272,7 @@ class WaterQuality:
         C_s = constant residual concentration that always remains (SI/US: mg/L)
         """
 
-        assert(parameters["C_s"] >= 0, self._generateErrorMessage("C_s", "Constant residual concentration", 0, minVal=0))
+        assert parameters["C_s"] >= 0, self._generateErrorMessage("C_s", "Constant residual concentration", 0, minVal=0)
 
         parameters = parameters
 
@@ -305,7 +305,7 @@ class WaterQuality:
         C_s = constant residual concentration that always remains (SI/US: mg/L)
         """
 
-        assert(parameters["C_s"] >= 0, self._generateErrorMessage("C_s", "Constant residual concentration", 0, minVal=0))
+        assert parameters["C_s"] >= 0, self._generateErrorMessage("C_s", "Constant residual concentration", 0, minVal=0)
 
         parameters = parameters
 
@@ -362,9 +362,9 @@ class WaterQuality:
         Qt  = sediment discharge (SI: kg/s, US: lb/s)
         """
 
-        assert(parameters["w"] >=0, self._generateErrorMessage("w", "Channel width", 0, minVal=0))
-        assert(parameters["Ss"] >=0, self._generateErrorMessage("Ss", "Specific gravity of sediment", 0, minVal=0))
-        assert(parameters["d50"] >=0, self._generateErrorMessage("d50", "Mean sediment particle diameter", 0, minVal=0))
+        assert parameters["w"] >=0, self._generateErrorMessage("w", "Channel width", 0, minVal=0)
+        assert parameters["Ss"] >=0, self._generateErrorMessage("Ss", "Specific gravity of sediment", 0, minVal=0)
+        assert parameters["d50"] >=0, self._generateErrorMessage("d50", "Mean sediment particle diameter", 0, minVal=0)
 
         parameters = parameters
 
@@ -457,8 +457,8 @@ class WaterQuality:
         c0  = intital concentration inside reactor (SI/US: mg/L)
         """
 
-        assert(parameters["n"] >=0, self._generateErrorMessage("n", "Reaction order", 0, minVal=0))
-        assert(parameters["c0"] >=0, self._generateErrorMessage("c0", "Intital concentration inside reactor", 0, minVal=0))
+        assert parameters["n"] >=0, self._generateErrorMessage("n", "Reaction order", 0, minVal=0)
+        assert parameters["c0"] >=0, self._generateErrorMessage("c0", "Intital concentration inside reactor", 0, minVal=0)
 
         # Get current time
         current_step = self.sim.current_time
@@ -502,10 +502,10 @@ class WaterQuality:
         E     = filter bed porosity (unitless)
         """
 
-        assert(parameters["Ceq0"] >=0, self._generateErrorMessage("Ceq0", "Initial DP or PP equilibrium concentration value for an event", 0, minVal=0))
-        assert(parameters["L"] >=0, self._generateErrorMessage("L", "Depth of soil media", 0, minVal=0))
-        assert(parameters["A"] >=0, self._generateErrorMessage("A", "Cross-sectional area", 0, minVal=0))
-        assert(0<= parameters["E"] <=1, self._generateErrorMessage("E", "Filter bed porosity", 2, minVal=0, maxVal=1))
+        assert parameters["Ceq0"] >=0, self._generateErrorMessage("Ceq0", "Initial DP or PP equilibrium concentration value for an event", 0, minVal=0)
+        assert parameters["L"] >=0, self._generateErrorMessage("L", "Depth of soil media", 0, minVal=0)
+        assert parameters["A"] >=0, self._generateErrorMessage("A", "Cross-sectional area", 0, minVal=0)
+        assert 0<= parameters["E"] <=1, self._generateErrorMessage("E", "Filter bed porosity", 2, minVal=0, maxVal=1)
 
         parameters = parameters
         t = 0


### PR DESCRIPTION
This removes the warning: <stdin>:1: SyntaxWarning: assertion is always true, perhaps remove parentheses?